### PR TITLE
#GH-12 Fix redirect after clicking "Delete task" button

### DIFF
--- a/config/process.php
+++ b/config/process.php
@@ -22,8 +22,14 @@ if (!empty($data)) {
     $deletedTask->setID($data['id']);
     $deletedTask->setDeleted($data['deleted']);
     $taskDAO->delete($deletedTask);
-    header("Location: /");
-    
+    $actualPage = $data['heading'];
+
+    if ($actualPage === 'To-do tasks') {
+      header("Location: /");
+    } else if ($actualPage === 'Done tasks') {
+      header("Location: /done");
+    }
+
   } else if ($data['type'] === 'complete') {
     $completedTask = new Task();
     $completedTask->setID($data['id']);

--- a/views/partials/delete-button.php
+++ b/views/partials/delete-button.php
@@ -2,6 +2,7 @@
   <input type="hidden" name="type" value="delete">
   <input type="hidden" name="id" value="<?= $task->getID() ?>">
   <input type="hidden" name="deleted" value="1">
+  <input type="hidden" name="heading" value="<?= $heading ?>">
   <button type="submit" class="ml-2 rounded-md bg-amber-600 px-3 py-2 text-white shadow-sm hover:bg-amber-500 disabled:bg-amber-500 disabled:text-amber-200">
     <i class="uil uil-trash-alt"></i>
   </button>


### PR DESCRIPTION
This pull request fixes #12 by updating the "Delete task" sent information and `delete` method process.

To achieve this, we needed to:
- Include the page heading (from the page that the task is being deleted) to be sent inside the "Delete task" button form;
- Include a validation inside the `delete` method process to verify the related page heading and redirect the user to the correct page view