### PR TITLE
GH-4 Add edit task feature

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -41,6 +41,21 @@ function closeNewTaskModalOnClick() {
   });
 }
 
+function openEditTaskModal(button) {
+  const editTaskModal = document.getElementById("edit-task-modal"),
+    taskTitle = button.getAttribute("task-title"),
+    taskDescription = button.getAttribute("task-description"),
+    taskId = button.getAttribute("task-id"),
+    editId = document.getElementById("edit-id"),
+    editTitle = document.getElementById("edit-title"),
+    editDescription = document.getElementById("edit-description");
+
+  editTaskModal.showModal();
+  editId.value = taskId;
+  editTitle.value = taskTitle;
+  editDescription.value = taskDescription;
+}
+
 function main() {
   closeNewTaskModalOnClick();
 }

--- a/config/process.php
+++ b/config/process.php
@@ -36,5 +36,13 @@ if (!empty($data)) {
 
     $taskDAO->complete($completedTask);
     header("Location: /");
+  } else if ($data['type'] === 'edit') {
+    $editedTask = new Task();
+    $editedTask->setID((int)$data['id']);
+    $editedTask->setTitle($data['title']);
+    $editedTask->setDescription($data['description']);
+
+    $taskDAO->edit($editedTask);
+    header("Location: /");
   }
 }

--- a/views/done.view.php
+++ b/views/done.view.php
@@ -46,10 +46,7 @@ $tasks = $taskDAO->read(1, 0);
       <div class="bg-amber-300 p-2 rounded-b-lg">
         <div class="flex justify-end">
           <div class="flex">
-            <?php
-            require(__DIR__ . '/partials/edit-button.php');
-            require(__DIR__ . '/partials/delete-button.php');
-            ?>
+            <?php require(__DIR__ . '/partials/delete-button.php'); ?>
           </div>
         </div>
       </div>

--- a/views/partials/edit-button.php
+++ b/views/partials/edit-button.php
@@ -1,7 +1,3 @@
-<form action="/config/process.php" method="post">
-  <input type="hidden" name="type" value="edit">
-  <input type="hidden" name="id" value="<?= $task->getID() ?>">
-  <button disabled type="submit" class="ml-2 rounded-md bg-amber-600 px-3 py-2 text-white shadow-sm hover:bg-amber-500 disabled:bg-amber-500 disabled:text-amber-200">
-    <i class="uil uil-edit"></i>
-  </button>
-</form>
+<button onclick="openEditTaskModal(this)" class="ml-2 rounded-md bg-amber-600 px-3 py-2 text-white shadow-sm hover:bg-amber-500 disabled:bg-amber-500 disabled:text-amber-200" task-id="<?= $task->getID() ?>" task-title="<?= $task->getTitle() ?>" task-description="<?= $task->getDescription() ?>">
+  <i class="uil uil-edit"></i>
+</button>

--- a/views/partials/edit-task.php
+++ b/views/partials/edit-task.php
@@ -1,0 +1,35 @@
+<dialog id="edit-task-modal" class="w-11/12 max-w-lg rounded-lg backdrop:bg-black/60">
+  <div class="bg-gray-50 px-4 pb-4 pt-2">
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold">
+        Edit task
+      </h2>
+      <button onclick="closeEditTaskModal()">
+        <i class="uil uil-times text-xl"></i>
+      </button>
+    </div>
+
+    <hr class="border-gray-200 my-2 w-full">
+    <p class="text-sm text-gray-400">
+      Edit task title/description, then click "Save" to apply changes.
+    </p>
+  </div>
+
+  <form action="/config/process.php" method="POST">
+    <input type="hidden" name="type" value="edit">
+    <div class="px-4 mt-2">
+      <label for="title" class="block text-sm font-medium leading-6 text-gray-900 md:text-base">Title</label>
+      <input type="text" name="title" id="title" maxlength="125" class="block w-full rounded-md border-0 p-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-base" required>
+    </div>
+
+    <div class="px-4 mt-2 mb-4">
+      <label for="description" class="block text-sm font-medium leading-6 text-gray-900 md:text-base">Description</label>
+      <textarea name="description" id="description" rows="4" maxlength="255" class="block w-full rounded-md border-0 p-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 text-sm placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 md:text-base resize-none"></textarea>
+    </div>
+
+    <div class="bg-gray-50 px-4 rounded-b-lg">
+      <button type="submit" class="mt-3 inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 sm:my-3 sm:w-auto md:text-base">Save</button>
+      <button type="reset" onclick="closeEditTaskModal()" class="my-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:my-0 sm:w-auto md:text-base">Cancel</button>
+    </div>
+  </form>
+</dialog>

--- a/views/partials/edit-task.php
+++ b/views/partials/edit-task.php
@@ -17,14 +17,16 @@
 
   <form action="/config/process.php" method="POST">
     <input type="hidden" name="type" value="edit">
+    <input type="hidden" name="id" id="edit-id">
+
     <div class="px-4 mt-2">
       <label for="title" class="block text-sm font-medium leading-6 text-gray-900 md:text-base">Title</label>
-      <input type="text" name="title" id="title" maxlength="125" class="block w-full rounded-md border-0 p-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-base" required>
+      <input type="text" name="title" id="edit-title" maxlength="125" class="block w-full rounded-md border-0 p-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-base" required>
     </div>
 
     <div class="px-4 mt-2 mb-4">
       <label for="description" class="block text-sm font-medium leading-6 text-gray-900 md:text-base">Description</label>
-      <textarea name="description" id="description" rows="4" maxlength="255" class="block w-full rounded-md border-0 p-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 text-sm placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 md:text-base resize-none"></textarea>
+      <textarea name="description" id="edit-description" rows="4" maxlength="255" class="block w-full rounded-md border-0 p-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 text-sm placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 md:text-base resize-none"></textarea>
     </div>
 
     <div class="bg-gray-50 px-4 rounded-b-lg">

--- a/views/partials/footer.php
+++ b/views/partials/footer.php
@@ -1,4 +1,7 @@
-<?php require_once(__DIR__ . '/new-task.php') ?>
+<?php
+require_once(__DIR__ . '/new-task.php');
+require_once(__DIR__ . '/edit-task.php');
+?>
 </div>
 </main>
 </div>


### PR DESCRIPTION
This pull request closes #4 by adding the needed logic that allow the user to edit a desired task information and save the new task information on the database.

To achieve this, we needed to:
- Create the "Edit task" modal structure;
- Update the old `edit-button.php` to fit the new logic;
- Include Javascript functions to open/close the "Edit task" modal;
- Include `edit` method process to deal with the task edition request

Additional information:
- Since there's no need to edit a done task, this pull request removes the "Edit" button from done tasks, preventing future issues
