### PR TITLE
Refactor: Optimize modal functions

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -34,6 +34,7 @@ function openModal(button) {
   }
 
   modal.showModal();
+  closeOnOutsideClick(modal);
 }
 
 function closeModal(modalId) {
@@ -41,37 +42,16 @@ function closeModal(modalId) {
   modal.close();
 }
 
-function closeModalOnOutsideClick() {
-  const newTaskModal = document.getElementById("create-task-modal");
-  const editTaskModal = document.getElementById("edit-task-modal");
-
-  newTaskModal.addEventListener("click", (e) => {
-    const dialogDimensions = newTaskModal.getBoundingClientRect();
+function closeOnOutsideClick(modal) {
+  modal.addEventListener("click", (e) => {
+    const dialogDimensions = modal.getBoundingClientRect();
     if (
       e.clientX < dialogDimensions.left ||
       e.clientX > dialogDimensions.right ||
       e.clientY < dialogDimensions.top ||
       e.clientY > dialogDimensions.bottom
     ) {
-      newTaskModal.close();
-    }
-  });
-
-  editTaskModal.addEventListener("click", (e) => {
-    const dialogDimensions = editTaskModal.getBoundingClientRect();
-    if (
-      e.clientX < dialogDimensions.left ||
-      e.clientX > dialogDimensions.right ||
-      e.clientY < dialogDimensions.top ||
-      e.clientY > dialogDimensions.bottom
-    ) {
-      editTaskModal.close();
+      modal.close();
     }
   });
 }
-
-function main() {
-  closeModalOnOutsideClick();
-}
-
-main();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -21,16 +21,7 @@ function openModal(button) {
     modal = document.getElementById(modalId);
 
   if (modalId === "edit-task-modal") {
-    const taskTitle = button.getAttribute("task-title"),
-      taskDescription = button.getAttribute("task-description"),
-      taskId = button.getAttribute("task-id"),
-      editId = document.getElementById("edit-id"),
-      editTitle = document.getElementById("edit-title"),
-      editDescription = document.getElementById("edit-description");
-
-    editId.value = taskId;
-    editTitle.value = taskTitle;
-    editDescription.value = taskDescription;
+    fillEditTaskModal(button);
   }
 
   modal.showModal();
@@ -54,4 +45,17 @@ function closeOnOutsideClick(modal) {
       modal.close();
     }
   });
+}
+
+function fillEditTaskModal(button) {
+  const taskTitle = button.getAttribute("task-title"),
+    taskDescription = button.getAttribute("task-description"),
+    taskId = button.getAttribute("task-id"),
+    editId = document.getElementById("edit-id"),
+    editTitle = document.getElementById("edit-title"),
+    editDescription = document.getElementById("edit-description");
+
+  editId.value = taskId;
+  editTitle.value = taskTitle;
+  editDescription.value = taskDescription;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -16,29 +16,29 @@ function closeWarning() {
   warningMsg.classList.add("hidden");
 }
 
-function openNewTaskModal() {
-  const newTaskModal = document.getElementById("create-task-modal");
-  newTaskModal.showModal();
+function openModal(button) {
+  const modalId = button.getAttribute("modal-id"),
+    modal = document.getElementById(modalId);
+
+  if (modalId === "edit-task-modal") {
+    const taskTitle = button.getAttribute("task-title"),
+      taskDescription = button.getAttribute("task-description"),
+      taskId = button.getAttribute("task-id"),
+      editId = document.getElementById("edit-id"),
+      editTitle = document.getElementById("edit-title"),
+      editDescription = document.getElementById("edit-description");
+
+    editId.value = taskId;
+    editTitle.value = taskTitle;
+    editDescription.value = taskDescription;
+  }
+
+  modal.showModal();
 }
 
 function closeNewTaskModal() {
   const newTaskModal = document.getElementById("create-task-modal");
   newTaskModal.close();
-}
-
-function openEditTaskModal(button) {
-  const editTaskModal = document.getElementById("edit-task-modal"),
-    taskTitle = button.getAttribute("task-title"),
-    taskDescription = button.getAttribute("task-description"),
-    taskId = button.getAttribute("task-id"),
-    editId = document.getElementById("edit-id"),
-    editTitle = document.getElementById("edit-title"),
-    editDescription = document.getElementById("edit-description");
-
-  editTaskModal.showModal();
-  editId.value = taskId;
-  editTitle.value = taskTitle;
-  editDescription.value = taskDescription;
 }
 
 function closeEditTaskModal() {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -36,14 +36,9 @@ function openModal(button) {
   modal.showModal();
 }
 
-function closeNewTaskModal() {
-  const newTaskModal = document.getElementById("create-task-modal");
-  newTaskModal.close();
-}
-
-function closeEditTaskModal() {
-  const editTaskModal = document.getElementById("edit-task-modal");
-  editTaskModal.close();
+function closeModal(modalId) {
+  const modal = document.getElementById(modalId);
+  modal.close();
 }
 
 function closeModalOnOutsideClick() {

--- a/views/partials/edit-task.modal.php
+++ b/views/partials/edit-task.modal.php
@@ -4,7 +4,7 @@
       <h2 class="text-lg font-semibold">
         Edit task
       </h2>
-      <button onclick="closeEditTaskModal()">
+      <button onclick="closeModal('edit-task-modal')">
         <i class="uil uil-times text-xl"></i>
       </button>
     </div>
@@ -38,7 +38,7 @@
         Save
       </button>
 
-      <button type="reset" onclick="closeEditTaskModal()" class="my-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:my-0 sm:w-auto md:text-base">
+      <button type="reset" onclick="closeModal('edit-task-modal')" class="my-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:my-0 sm:w-auto md:text-base">
         Cancel
       </button>
     </div>

--- a/views/partials/edit.button.php
+++ b/views/partials/edit.button.php
@@ -1,3 +1,3 @@
-<button onclick="openEditTaskModal(this)" class="ml-2 rounded-md bg-amber-600 px-3 py-2 text-white text-sm font-semibold shadow-sm sm:text-base hover:bg-amber-500 disabled:bg-amber-500 disabled:text-amber-200" task-id="<?= $task->getID() ?>" task-title="<?= $task->getTitle() ?>" task-description="<?= $task->getDescription() ?>">
+<button onclick="openModal(this)" modal-id="edit-task-modal" task-id="<?= $task->getID() ?>" task-title="<?= $task->getTitle() ?>" task-description="<?= $task->getDescription() ?>" class="ml-2 rounded-md bg-amber-600 px-3 py-2 text-white text-sm font-semibold shadow-sm sm:text-base hover:bg-amber-500 disabled:bg-amber-500 disabled:text-amber-200">
   <i class="uil uil-edit"></i> Edit
 </button>

--- a/views/partials/heading.php
+++ b/views/partials/heading.php
@@ -8,7 +8,7 @@
 
     <?php if ($heading === 'To-do') : ?>
       <div class="fixed bottom-2 right-4 sm:static">
-        <button type="button" onclick="openNewTaskModal()" class="bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm rounded-md hover:bg-indigo-500 md:text-base">
+        <button type="button" onclick="openModal(this)" modal-id="new-task-modal" class="bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm rounded-md hover:bg-indigo-500 md:text-base">
           <i class="uil uil-plus"></i> New task
         </button>
       </div>

--- a/views/partials/new-task.modal.php
+++ b/views/partials/new-task.modal.php
@@ -4,7 +4,7 @@
       <h2 class="text-lg font-semibold">
         Create a new task
       </h2>
-      <button onclick="closeNewTaskModal()">
+      <button onclick="closeModal('new-task-modal')">
         <i class="uil uil-times text-xl"></i>
       </button>
     </div>
@@ -36,7 +36,7 @@
         Create task
       </button>
 
-      <button type="reset" onclick="closeNewTaskModal()" class="my-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:my-0 sm:w-auto md:text-base">
+      <button type="reset" onclick="closeModal('new-task-modal')" class="my-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:my-0 sm:w-auto md:text-base">
         Cancel
       </button>
     </div>

--- a/views/partials/new-task.modal.php
+++ b/views/partials/new-task.modal.php
@@ -1,4 +1,4 @@
-<dialog id="create-task-modal" class="w-11/12 max-w-lg rounded-lg backdrop:bg-black/60">
+<dialog id="new-task-modal" class="w-11/12 max-w-lg rounded-lg backdrop:bg-black/60">
   <div class="bg-gray-50 px-4 pb-4 pt-2">
     <div class="flex items-center justify-between">
       <h2 class="text-lg font-semibold">


### PR DESCRIPTION
This pull request optimizes the modal open/close functions and the "Edit task" modal auto fill function.

To achieve this, we needed to:
- Add generic `openModal` function which works with any modal;
- Remove old specific `openNewTaskModal` and `openEditTaskModal` functions;
- Update `closeModalOnOutsideClick` function, making it work with any modal (more generic);
- Rename `closeModalOnOutsideClick` function to `closeOnOutsideClick`;
- Add `fillEditTaskModal` function to fill the "Edit task" modal fields when opening;
- Include `fillEditTaskModal` and `closeOnOutsideClick` functions inside `openModal` function;
- Update "New task" button to fit the new modal functions;
- Update "Edit" button to fit the new modal functions;
- Update "New task" modal component to fit the new modal functions;
- Update "Edit task" modal component to fit the new modal functions;

By merging this pull request, we'll optimize our code by removing ~21 needless lines and making modal functions more generic & reusable.