### PR TITLE
GH-21 Add header menu "Register" button

### DIFF
--- a/views/partials/header.php
+++ b/views/partials/header.php
@@ -60,11 +60,11 @@
 
       <div class="px-2 pb-3 pt-2 sm:px-3">
         <div class="flex flex-col items-center justify-center sm:flex-row sm:space-y-0 sm:justify-center sm:space-x-2">
-          <a href="/login" class="inline-flex w-11/12 justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 sm:w-2/4">
+          <a href="/login" class="w-11/12 justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm text-center font-semibold text-white shadow-sm hover:bg-indigo-500 sm:w-2/4">
             <button>Login</button>
           </a>
 
-          <hr class="border-gray-700 w-3/4 mx-auto">
+          <hr class="border-gray-700 w-3/4 my-2">
 
           <a href="/register" class="w-11/12 justify-center rounded-md bg-white px-3 py-2 text-sm text-center font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
             Register

--- a/views/partials/header.php
+++ b/views/partials/header.php
@@ -34,6 +34,10 @@
           <a href="/login" class="rounded-md bg-indigo-600 px-12 py-2 text-sm font-semibold text-white text-center shadow-sm hover:bg-indigo-500 md:text-base">
             <button>Login</button>
           </a>
+
+          <a href="/register" class="rounded-md bg-white px-3 py-2 text-base font-semibold text-gray-900 text-center shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100">
+            <button>Register</button>
+          </a>
         </div>
       </div>
 

--- a/views/partials/header.php
+++ b/views/partials/header.php
@@ -31,7 +31,7 @@
         </div>
 
         <div class="hidden flex space-x-2 md:block">
-          <a href="/login" class="rounded-md bg-indigo-600 px-12 py-2 text-sm font-semibold text-white text-center shadow-sm hover:bg-indigo-500 md:text-base">
+          <a href="/login" class="rounded-md bg-indigo-600 px-12 py-2 text-base font-semibold text-white text-center shadow-sm hover:bg-indigo-500">
             <button>Login</button>
           </a>
 

--- a/views/partials/header.php
+++ b/views/partials/header.php
@@ -63,6 +63,12 @@
           <a href="/login" class="inline-flex w-11/12 justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 sm:w-2/4">
             <button>Login</button>
           </a>
+
+          <hr class="border-gray-700 w-3/4 mx-auto">
+
+          <a href="/register" class="w-11/12 justify-center rounded-md bg-white px-3 py-2 text-sm text-center font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+            Register
+          </a>
         </div>
       </div>
     </div>

--- a/views/partials/header.php
+++ b/views/partials/header.php
@@ -64,10 +64,10 @@
             <button>Login</button>
           </a>
 
-          <hr class="border-gray-700 w-3/4 my-2">
+          <hr class="border-gray-700 w-3/4 my-2 sm:hidden">
 
-          <a href="/register" class="w-11/12 justify-center rounded-md bg-white px-3 py-2 text-sm text-center font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
-            Register
+          <a href="/register" class="w-11/12 justify-center rounded-md bg-white px-3 py-2 text-sm text-center font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:w-2/4">
+            <button>Register</button>
           </a>
         </div>
       </div>


### PR DESCRIPTION
This pull request closes #21 by adding the mobile and web version header menu "Register" button with its pre-defined redirection.

Some minor updates were needed on the "Login" button to fit the "Register" button.