### PR TITLE
Feat: Add user id to task creation/reading

### DIFF
--- a/config/process.tasks.php
+++ b/config/process.tasks.php
@@ -9,10 +9,12 @@ if (!empty($data)) {
   if ($data['type'] === 'create') {
     $taskTitle = $data['title'];
     $taskDescription = $data['description'];
+    $taskUser = $data['user-id'];
 
     $newTask = new Task();
     $newTask->setTitle($taskTitle);
     $newTask->setDescription($taskDescription);
+    $newTask->setUserID($taskUser);
 
     $taskDAO->create($newTask);
     header("Location: /todo");

--- a/models/Task.php
+++ b/models/Task.php
@@ -6,6 +6,7 @@ class Task
   private $description;
   private $completed;
   private $deleted;
+  private $user_id;
 
   public function getID(): int
   {
@@ -56,12 +57,22 @@ class Task
   {
     $this->deleted = $deleted;
   }
+
+  public function getUserId(): int
+  {
+    return $this->user_id;
+  }
+
+  public function setUserId(int $user_id): void
+  {
+    $this->user_id = $user_id;
+  }
 }
 
 interface TaskInterface
 {
   public function create(Task $task);
-  public function read(int $completed, int $deleted);
+  public function read(int $completed, int $deleted, int $userId);
   public function edit(Task $task);
   public function complete(Task $task);
   public function delete(Task $task);

--- a/models/dao/TaskDAO.php
+++ b/models/dao/TaskDAO.php
@@ -14,16 +14,19 @@ class TaskDAO implements TaskInterface
   {
     $taskTitle = $task->getTitle();
     $taskDescription = $task->getDescription();
-    $stmt = $this->pdo->prepare("INSERT INTO tasks (title, description) VALUES (:title, :description)");
+    $taskUser = $task->getUserID();
+    $stmt = $this->pdo->prepare("INSERT INTO tasks (title, description, user_id) VALUES (:title, :description, :user_id)");
     $stmt->bindParam(':title', $taskTitle);
     $stmt->bindParam(':description', $taskDescription);
+    $stmt->bindParam(':user_id', $taskUser);
     $stmt->execute();
   }
 
-  public function read(int $completed, int $deleted): array
+  public function read(int $completed, int $deleted, int $userId): array
   {
     $tasks = [];
-    $stmt = $this->pdo->prepare("SELECT * FROM tasks WHERE completed = :completed AND deleted = :deleted ORDER BY id DESC");
+    $stmt = $this->pdo->prepare("SELECT * FROM tasks WHERE user_id = :user_id AND completed = :completed AND deleted = :deleted ORDER BY id DESC");
+    $stmt->bindParam(':user_id', $userId);
     $stmt->bindParam(':completed', $completed);
     $stmt->bindParam(':deleted', $deleted);
     $stmt->execute();

--- a/views/partials/modal.new-task.php
+++ b/views/partials/modal.new-task.php
@@ -17,6 +17,7 @@
 
   <form action="/config/process.tasks.php" method="POST">
     <input type="hidden" name="type" value="create">
+    <input type="number" name="user-id" value="<?= $userData? $userData->getId() : "" ?>">
     <div class="px-4 mt-2">
       <label for="title" class="block text-sm font-medium leading-6 text-gray-900 md:text-base">
         Title

--- a/views/partials/modal.new-task.php
+++ b/views/partials/modal.new-task.php
@@ -17,7 +17,7 @@
 
   <form action="/config/process.tasks.php" method="POST">
     <input type="hidden" name="type" value="create">
-    <input type="number" name="user-id" value="<?= $userData? $userData->getId() : "" ?>">
+    <input type="hidden" name="user-id" value="<?= $userData? $userData->getId() : "" ?>">
     <div class="px-4 mt-2">
       <label for="title" class="block text-sm font-medium leading-6 text-gray-900 md:text-base">
         Title

--- a/views/view.done.php
+++ b/views/view.done.php
@@ -6,10 +6,10 @@ require_once(__DIR__ . '/../models/dao/TaskDAO.php');
 require_once(__DIR__ . '/../models/dao/UserDAO.php');
 
 $taskDAO = new TaskDAO($pdo);
-$tasks = $taskDAO->read(1, 0);
-
 $userDAO = new UserDAO($pdo);
+
 $userData = $userDAO->verifyToken(true);
+$tasks = $taskDAO->read(1, 0, $userData->getID());
 ?>
 
 <section class="mt-44">

--- a/views/view.todo.php
+++ b/views/view.todo.php
@@ -5,11 +5,11 @@ require_once(__DIR__ . '/../views/partials/template.heading.php');
 require_once(__DIR__ . '/../models/dao/TaskDAO.php');
 require_once(__DIR__ . '/../models/dao/UserDAO.php');
 
-$taskDAO = new TaskDAO($pdo);
-$tasks = $taskDAO->read(0, 0);
-
 $userDAO = new UserDAO($pdo);
+$taskDAO = new TaskDAO($pdo);
+
 $userData = $userDAO->verifyToken(true);
+$tasks = $taskDAO->read(0, 0, $userData->getID());
 ?>
 
 <section class="mt-44">


### PR DESCRIPTION
This pull request adds the feature to consider user-id on task creation and reading, making it possible to relate each task with it's own creator, preventing users to see tasks from others.